### PR TITLE
Fixes unittest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ cache:
 
 # Command to run tests, e.g. python setup.py test
 script:
-  - python -m unittest tests.test_extract_dataframe
+  - cd ./tests/
+  - python -m unittest test_extract_dataframe


### PR DESCRIPTION
travis build fails because the unittest package is made to find tests
 in same directory as its being run on